### PR TITLE
Extending docker-image-build-push workflow by push_to_aws flag

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -15,6 +15,9 @@ on:
       image_tag:
         type: string
         default: latest
+      push_to_aws:
+        type: boolean
+        default: false
     secrets:
       TFAUTOMATION_AWS_ACCESS_KEY:
          required: true
@@ -34,6 +37,9 @@ on:
       image_tag:
         type: string
         default: latest
+      push_to_aws:
+        type: boolean
+        default: true
                 
 jobs:
   push:
@@ -54,7 +60,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         
       - name: Build, tag, and push image to Amazon ECR
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' || inputs.push_to_aws }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repo }}

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -39,7 +39,7 @@ on:
         default: latest
       push_to_aws:
         type: boolean
-        default: true
+        default: false
                 
 jobs:
   push:

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -70,7 +70,7 @@ jobs:
           docker tag $ECR_REPOSITORY $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: Build image # For manually checking if docker build is working.
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.push_to_aws }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repo }}


### PR DESCRIPTION
# Description

As of right now, we only build new containers when a PR or push happens at meltano-staging.
However, since changes made to one of the installed taps itself does not trigger the building of a new container, we need a way to manually build and push a new container. 
So I have added a new flag called push_to_aws that is by default set to false. On workflow dispatches where that flag is set to true or on pushes to the main branch, the container will be pushed to AWS 