### PR TITLE
Add step for fabric to warm up the SQL pool

### DIFF
--- a/.github/workflows/dbt-test.yml
+++ b/.github/workflows/dbt-test.yml
@@ -405,6 +405,17 @@ jobs:
     # Building the docker Image from the docker Files for each database.
     - name: Build ${{ inputs.db_name }} image
       run: docker build -t dv4dbt-${{ inputs.db_name }} --build-arg DBT_DV4DBT_REVISION=${{ inputs.dv4dbt-revision }} --build-arg SSH_PRIVATE_REPO_KEY="${{ secrets.SSH_PRIVATE_REPO_KEY }}" -f $GITHUB_WORKSPACE/db-environments/${{ inputs.db_name }}/Dockerfile .
+  
+    # Waking up the fabric database
+    - name: Fabric warm up SQL Pool
+      if: ${{ inputs.db_name == 'fabric'}}
+      run: |
+        docker run --name dv4dbt-v1-i0-${{ inputs.db_name }} --network host -e DBT_INCREMENTAL_RUN=0 dv4dbt-${{ inputs.db_name }} dbt seed --profiles-dir /user/app/profiles --profile ${{ inputs.db_name }} 
+    
+    # Ensuring Fabric SQL pool is warmed up
+    - name: Wait 42s
+      if: ${{ inputs.db_name == 'fabric' }}
+      run: sleep 42
     
     # Running all Tests with different Variables.
     - name: Run ${{ inputs.db_name }} container DBT_INCREMENTAL_RUN=0 Variables set to True


### PR DESCRIPTION
We are repeatedly getting the error that the SQL pool is warming up in the pipeline:
![image](https://github.com/user-attachments/assets/090dfda9-9eff-49f9-ad8a-813e29488b77)

As countermeasure I added a step with `dbt seed` followed by a wait step for 42 to seconds to ensure the SQL pool is properly warmed up for the subsequent pipeline runs.

More on the error message:
https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-42109-database-engine-error